### PR TITLE
Mentioning proper software citation.

### DIFF
--- a/developer-guidelines/01-basics.rst
+++ b/developer-guidelines/01-basics.rst
@@ -34,6 +34,9 @@ All development should be made available publicly under `open source <https://op
 
 #. Ensure your software is usable and accessible.
 
+#. Maintain human- and machine-readable citation information for your software in a ``CITATION.cff``. 
+Start with `an example <https://citation-file-format.github.io>`__ or use `a tool <https://citation-file-format.github.io/cff-initializer-javascript/>`__.
+
 #. Implement a :doc:`release policy <../policies/releasing>` and keep a :doc:`changelog <06-changelog>`.
 
 #. Add a code of conduct in a ``CODE_OF_CONDUCT.md``, like :download:`we do <../CODE_OF_CONDUCT.md>`.


### PR DESCRIPTION
Mentioning `CITATION.cff` under Basics.
Adding a reference to an example and to the CFFinit tool.